### PR TITLE
Fixes #503; Correct event owner for `pr_merged` events

### DIFF
--- a/scraper/src/github-scraper/parseEvents.ts
+++ b/scraper/src/github-scraper/parseEvents.ts
@@ -166,7 +166,7 @@ export const parseEvents = async (events: IGitHubEvent[]) => {
           event.payload.pull_request?.merged
         ) {
           const turnaroundTime = await calculateTurnaroundTime(event);
-          appendEvent(user, {
+          appendEvent(event.payload.pull_request.user.login, {
             type: "pr_merged",
             title: `${event.repo.name}#${event.payload.pull_request.number}`,
             time: eventTime?.toISOString(),


### PR DESCRIPTION
- https://github.com/ohcnetwork/leaderboard/pull/512

`pr_merged` events was using the event actor (in this case the one who merged the PR). However, in leaderboard `pr_merged` events are associated to the PR authors for incentivizing the contributor.


Regression from recent scraper refactor from python to typescript