### PR TITLE
fix: Show nothing instead of 'Still waiting for this' on people page #498

### DIFF
--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -27,7 +27,7 @@ export default async function Page() {
                   github={c.github}
                   name={c.name}
                   title={c.title}
-                  content={c.content}
+                  content={c.content && c.content.trim() !== "Still waiting for this" ? c.content : ""}
                 >
                   <Link href={`/contributors/${c.github}`}>
                     <Image

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION

This PR fixes the issue where the "Still waiting for this" message was being displayed on the people page when there was no content. Now, if there's no valid content, nothing will be shown instead.

Fixes #498 

