### PR TITLE
Fix client-side relative time calculation for statically generated routes ..

### DIFF
--- a/components/RelativeTime.tsx
+++ b/components/RelativeTime.tsx
@@ -1,12 +1,26 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+
 type Props = {
   time: string | Date | number;
   className?: string;
 };
 
 export default function RelativeTime(props: Props) {
-  const time = new Date(props.time);
-  const relative = getRelativeTimeString(time);
+  const [relative, setRelative] = useState("");
+  const time = useMemo(() => new Date(props.time), [props.time]);
   const absolute = time.toString();
+
+  useEffect(() => {
+    const updateRelativeTime = () => {
+      setRelative(getRelativeTimeString(time));
+    };
+
+    updateRelativeTime();
+
+    const intervalId = setInterval(updateRelativeTime, 60000);
+    return () => clearInterval(intervalId);
+  }, [time]);
 
   return (
     <time

--- a/components/contributors/BadgeIcons.tsx
+++ b/components/contributors/BadgeIcons.tsx
@@ -77,13 +77,13 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
         {/* model */}
 
         <div
-          className={`absolute inset-x-0 z-20 mx-4 mt-1 translate-y-5 rounded-lg bg-secondary-800 text-white shadow-2xl transition-all md:inset-auto md:-left-[calc(125px-50%)] md:top-[calc(100%+10px)] md:mx-0 md:w-[250px] ${
+          className={`absolute inset-x-0 z-20 mx-4 mt-1 translate-y-5 rounded-lg bg-secondary-200 text-black shadow-2xl transition-all dark:bg-secondary-800 dark:text-white md:inset-auto md:-left-[calc(125px-50%)] md:top-[calc(100%+10px)] md:mx-0 md:w-[250px] ${
             showModel
               ? "visible translate-y-0 opacity-100"
               : "invisible opacity-0"
           }`}
         >
-          <div className="flex items-center justify-center rounded-t-lg border-b border-secondary-700 bg-secondary-950 px-4 py-3">
+          <div className="flex items-center justify-center rounded-t-lg border-b border-secondary-700 bg-secondary-300 px-4 py-3 dark:bg-secondary-700">
             <div className="relative h-24 w-24">
               {skill.currentLevel && (
                 <>
@@ -132,13 +132,13 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
 
             <i className="fas fa-circle" />
           </div>
-          <div className="px-4 pb-4 pt-2">
-            <p className="pb-2 font-bold">{skill.label}</p>
+          <div className="bg-white px-4 pb-4 pt-2 text-black dark:bg-secondary-800 dark:text-white">
+            <p className="pb-2 font-bold text-foreground">{skill.label}</p>
             <div className="space-y-1 text-sm">
               {skill.levels.map((level: any, index: number) => (
                 <div
                   key={level.value}
-                  className="flex items-center font-medium text-secondary-400"
+                  className="flex items-center font-medium text-secondary-500 dark:text-secondary-300"
                 >
                   <p
                     className={`shrink-0 rounded px-1 py-0.5 ${
@@ -147,7 +147,7 @@ export default function BadgeIcons({ skill }: { skill: Skill }) {
                         (l) => l.value === skill.currentLevel?.value,
                       )
                         ? "bg-green-400 text-white"
-                        : "bg-secondary-700 opacity-40 grayscale"
+                        : "bg-secondary-400 opacity-40 grayscale dark:bg-secondary-700"
                     }`}
                   >
                     {level.label}


### PR DESCRIPTION
Fix #422 

### Issue:
The `RelativeTime` component displayed incorrect relative time when rendered on statically generated routes since it was computed server-side and did not update based on the client's time.

### Solution:
- Refactored the `RelativeTime` component to compute the relative time on the client side.
- Added the `"use client"` directive to ensure that the component runs entirely on the client side.
- Implemented `useEffect` and `useState` to calculate and update relative time every minute dynamically.
- Ensured the text representation of relative time is accurate on client-side rendering, fixing the issue of stale time displays on static pages.

This update addresses the problem by making the relative time always reflect the current time on the client side, providing an accurate user experience.
