### PR TITLE
Add Statistics Summary Cards to Leaderboard

### DIFF
--- a/app/leaderboard/[duration]/Leaderboard.tsx
+++ b/app/leaderboard/[duration]/Leaderboard.tsx
@@ -20,6 +20,9 @@ import { HiSortAscending, HiSortDescending } from "react-icons/hi";
 import { Popover } from "@headlessui/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import { BiGitPullRequest } from "react-icons/bi";
+import { GoIssueOpened, GoIssueClosed } from "react-icons/go";
+import { VscGitPullRequestClosed } from "react-icons/vsc";
 
 const filterBySearchTerm = (searchTermLC: string) => {
   return (item: LeaderboardAPIResponse[number]) =>
@@ -218,6 +221,71 @@ export default function Leaderboard(props: Props) {
               className="w-full"
             />
             <OtherFilters />
+          </div>
+        </div>
+
+        {/* Stats Summary */}
+        <div className="mx-4 mt-4 rounded-lg border border-primary-500 p-4 md:mx-0">
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            <div className="flex items-center space-x-2 rounded-lg border border-secondary-600 p-3 dark:border-secondary-300">
+              <GoIssueOpened className="text-2xl text-green-500" />
+              <div>
+                <p className="text-sm text-secondary-500 dark:text-secondary-300">
+                  Issues Opened
+                </p>
+                <p className="text-xl font-semibold">
+                  {resultSet.reduce(
+                    (sum, user) => sum + user.highlights.issue_opened,
+                    0,
+                  )}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center space-x-2 rounded-lg border border-secondary-600 p-3 dark:border-secondary-300">
+              <GoIssueClosed className="text-2xl text-purple-500" />
+              <div>
+                <p className="text-sm text-secondary-500 dark:text-secondary-300">
+                  Issues Closed
+                </p>
+                <p className="text-xl font-semibold">
+                  {resultSet.reduce(
+                    (sum, user) => sum + user.highlights.issue_closed,
+                    0,
+                  )}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center space-x-2 rounded-lg border border-secondary-600 p-3 dark:border-secondary-300">
+              <BiGitPullRequest className="text-2xl text-blue-500" />
+              <div>
+                <p className="text-sm text-secondary-500 dark:text-secondary-300">
+                  PRs Opened
+                </p>
+                <p className="text-xl font-semibold">
+                  {resultSet.reduce(
+                    (sum, user) => sum + user.highlights.pr_opened,
+                    0,
+                  )}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center space-x-2 rounded-lg border border-secondary-600 p-3 dark:border-secondary-300">
+              <VscGitPullRequestClosed className="text-2xl text-orange-500" />
+              <div>
+                <p className="text-sm text-secondary-500 dark:text-secondary-300">
+                  PRs Merged
+                </p>
+                <p className="text-xl font-semibold">
+                  {resultSet.reduce(
+                    (sum, user) => sum + user.highlights.pr_merged,
+                    0,
+                  )}
+                </p>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -147,6 +147,8 @@ export async function getContributorBySlug(file: string, detail = false) {
           acc.issue_assigned + (activity.type === "issue_assigned" ? 1 : 0),
         issue_opened:
           acc.issue_opened + (activity.type === "issue_opened" ? 1 : 0),
+        issue_closed:
+          acc.issue_closed + (activity.type === "issue_closed" ? 1 : 0),
         discussion_created:
           acc.discussion_created +
           (activity.type === "discussion_created" ? 2 : 0),
@@ -169,6 +171,7 @@ export async function getContributorBySlug(file: string, detail = false) {
       pr_reviewed: 0,
       issue_assigned: 0,
       issue_opened: 0,
+      issue_closed: 0,
       discussion_created: 0,
       discussion_answered: 0,
       discussion_comment_created: 0,
@@ -209,6 +212,7 @@ export async function getContributorBySlug(file: string, detail = false) {
       pr_collaborated: weightedActivity.pr_collaborated,
       issue_assigned: weightedActivity.issue_assigned,
       issue_opened: weightedActivity.issue_opened,
+      issue_closed: weightedActivity.issue_closed,
       discussion_created: weightedActivity.discussion_created,
       discussion_answered: weightedActivity.discussion_answered,
       discussion_comment_created: weightedActivity.discussion_comment_created,
@@ -288,6 +292,7 @@ const HIGHLIGHT_KEYS = [
   "pr_collaborated",
   "issue_assigned",
   "issue_opened",
+  "issue_closed",
   "discussion_created",
   "discussion_answered",
   "discussion_comment_created",
@@ -313,6 +318,7 @@ const HighlightsReducer = (acc: Highlights, day: Highlights) => {
     pr_collaborated: acc.pr_collaborated + (day.pr_collaborated ?? 0),
     issue_assigned: acc.issue_assigned + (day.issue_assigned ?? 0),
     issue_opened: acc.issue_opened + (day.issue_opened ?? 0),
+    issue_closed: acc.issue_closed + (day.issue_closed ?? 0),
     discussion_created: acc.discussion_created + (day.discussion_created ?? 0),
     discussion_answered:
       acc.discussion_answered + (day.discussion_answered ?? 0),
@@ -331,6 +337,7 @@ const HighlightsInitialValue = {
   pr_collaborated: 0,
   issue_assigned: 0,
   issue_opened: 0,
+  issue_closed: 0,
   discussion_created: 0,
   discussion_answered: 0,
   discussion_comment_created: 0,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,7 @@ export interface Highlights {
   pr_collaborated: number;
   issue_assigned: number;
   issue_opened: number;
+  issue_closed: number;
   pr_stale?: number;
   discussion_created: number;
   discussion_answered: number;
@@ -59,6 +60,7 @@ export interface WeekSummary {
   pr_collaborated: number;
   issue_assigned: number;
   issue_opened: number;
+  issue_closed: number;
   discussion_created: number;
   discussion_answered: number;
   discussion_comment_created: number;

--- a/scraper/src/github-scraper/types.ts
+++ b/scraper/src/github-scraper/types.ts
@@ -135,6 +135,7 @@ export const ACTIVITY_TYPES = [
   "issue_closed",
   "pr_reviewed",
   "issue_opened",
+  "issue_closed",
   "eod_update",
   "pr_opened",
   "pr_merged",


### PR DESCRIPTION
Added a new statistics section between filters and leaderboard that displays:

- Total Issues Opened/Closed
- Total PRs Opened/Merged
- Color-coded icons for each metric

> ☝🏼 wrote by cursor

<img width="1707" alt="image" src="https://github.com/user-attachments/assets/f290330b-b74d-4be9-9b1f-60a72a26cf4b">
