### PR TITLE
Update project board script to treat contributors as first class citizens of the cache

### DIFF
--- a/scraper/src/github-scraper/projectItems.ts
+++ b/scraper/src/github-scraper/projectItems.ts
@@ -97,7 +97,7 @@ async function getProjectBoardItems(projectId: string) {
                             ... on Issue {
                                 url
                                 closedAt
-                                state
+                                stateReason
                                 author {
                                     login
                                 }
@@ -157,7 +157,7 @@ async function getProjectBoardItems(projectId: string) {
 
       let completedAt = null;
 
-      if (node.type === "ISSUE" && node.content.state === "CLOSED") {
+      if (node.type === "ISSUE" && node.content.stateReason === "COMPLETED") {
         completedAt = node.content.closedAt;
       }
       if (node.type === "PULL_REQUEST" && node.content.merged) {


### PR DESCRIPTION
- Project board cached items are now unique for each item and contributor. This allows filtering through flatgithub explorer much easily.
- Also tagged by `completedAtMonth` to ease filtering contributions closed (as completed)/merged in the month.

- Fixes https://github.com/ohcnetwork/leaderboard-data/issues/71

<img width="2672" alt="image" src="https://github.com/user-attachments/assets/abc3f9e1-b7e0-4d5d-aab9-3d098c957cf6">
