### PR TITLE
fix : Ensure scraper does not fetch bot events

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -84,7 +84,9 @@ let contributorSlugs: Awaited<ReturnType<typeof getContributorsSlugs>> | null =
 export async function getContributorsSlugs(): Promise<{ file: string }[]> {
   if (!contributorSlugs) {
     const files = await readdir(`${root}`);
-    contributorSlugs = files.map((file) => ({ file }));
+    contributorSlugs = files
+      .filter((slug) => !slug.includes("[bot]"))
+      .map((file) => ({ file }));
   }
   return contributorSlugs;
 }


### PR DESCRIPTION
Proposed Changes

Fix: #554

Description 

i have just filter out the [bot] slug file name while picking it  in first rendering . 

Reviewer(s)

@rithviknishad 


