### PR TITLE
Add relative time for push event on feed page

### DIFF
--- a/components/gh_events/GitHubEvent.tsx
+++ b/components/gh_events/GitHubEvent.tsx
@@ -181,8 +181,12 @@ export default function GitHubEvent({ event }: { event?: IGitHubEvent }) {
             <span className="hidden sm:inline">{event.repo.name}</span>
             <span className="sm:hidden">
               {event.repo.name.replace(`${env.NEXT_PUBLIC_GITHUB_ORG}/`, "")}
-            </span>
+            </span>{" "}
           </Link>
+          <RelativeTime
+            className="inline text-sm text-secondary-400 underline"
+            time={event.created_at}
+          />
         </div>
       );
       body = (


### PR DESCRIPTION
Fixes #593 

- Adds relative time in the title for `PushEvent` type events on feed page

Before
![image](https://github.com/user-attachments/assets/c95728fe-c23c-4469-802d-8a9134719f12)


After
![image](https://github.com/user-attachments/assets/99cdaa1a-b287-4d6d-be08-995d82b62cdf)
