### PR TITLE
Add supports for `pullHistoricalGitHubActivites` to fetch discussions

### DIFF
--- a/scripts/pullHistoricalGitHubActivities.js
+++ b/scripts/pullHistoricalGitHubActivities.js
@@ -1,11 +1,13 @@
 /**
  * Script to populate the data-repo with historical information from GitHub.
  *
- * Supports populating the ollowing activity types:
+ * Supports populating the following activity types:
  *
  * - [x] issue_opened
  * - [x] pr_opened
  * - [x] pr_merged
+ *
+ * Supports populating GitHub Discussions
  */
 
 const { join } = require("path");
@@ -200,6 +202,161 @@ const isBlacklisted = (login) => {
   return login.includes("[bot]") || blacklistedAccounts.includes(login);
 };
 
+const discussionQuery = `query($org: String!, $cursor: String) {
+  organization(login: $org) {
+    repositories(first: 100, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          name
+            discussions(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            edges {
+              node {
+                title
+                body
+                author {
+                  login
+                }
+                url
+                isAnswered
+                category {
+                  name
+                  emojiHTML
+                }
+                comments(first: 10) {
+                  edges {
+                    node {
+                      author {
+                        login
+                      }
+                    }
+                  }
+                }
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+async function getAllDiscussions(endDate, startDate) {
+  const iterator = octokit.graphql.paginate.iterator(discussionQuery, { org });
+
+  let discussionsList = [];
+
+  for await (const response of iterator) {
+    const repositories = response.organization.repositories.edges;
+
+    for (const repo of repositories) {
+      const discussions = repo.node.discussions.edges.map((discussion) => ({
+        repository: repo.node.name,
+        discussion: discussion.node,
+      }));
+
+      const isDiscussionOutOfDateRange = discussions.find((d) => {
+        const createdAt = new Date(d.discussion.createdAt);
+        const updatedAt = new Date(d.discussion.updatedAt);
+
+        return (
+          (createdAt <= new Date(startDate) &&
+            createdAt >= new Date(endDate)) ||
+          (updatedAt <= new Date(startDate) && updatedAt >= new Date(endDate))
+        );
+      });
+      if (isDiscussionOutOfDateRange) {
+        return discussionsList;
+      }
+      discussionsList = discussionsList.concat(discussions);
+    }
+  }
+  return discussionsList;
+}
+
+async function parseDiscussionData(allDiscussions, endDate, startDate) {
+  const discussionsWithinDateRange = allDiscussions.filter((d) => {
+    const createdAt = new Date(d.discussion.createdAt);
+    const updatedAt = new Date(d.discussion.updatedAt);
+
+    return (
+      (createdAt >= new Date(startDate) && createdAt <= new Date(endDate)) ||
+      (updatedAt >= new Date(startDate) && updatedAt <= new Date(endDate))
+    );
+  });
+  const parsedDiscussions = discussionsWithinDateRange.map((d) => {
+    const participants = d.discussion.comments.edges.map(
+      (comment) => comment.node.author.login,
+    );
+    return {
+      source: "github",
+      title: d.discussion.title,
+      text: d.discussion.body,
+      author: d.discussion.author.login,
+      link: d.discussion.url,
+      isAnswered: d.discussion.isAnswered,
+      time: d.discussion.createdAt,
+      updateTime: d.discussion.updatedAt,
+      category: {
+        name: d.discussion.category.name,
+        emoji: d.discussion.category.emojiHTML.replace(/<\/?div>/g, ""),
+      },
+      participants: participants || [],
+      repository: d.repository,
+    };
+  });
+  return parsedDiscussions;
+}
+
+async function mergeDiscussions(oldData, newDiscussions) {
+  const mergedDiscussions = [...oldData];
+  if (!newDiscussions) {
+    return mergedDiscussions;
+  }
+  newDiscussions.forEach((newDiscussion) => {
+    const oldIndex = oldData.findIndex(
+      (oldDiscussion) => oldDiscussion.link === newDiscussion.link,
+    );
+
+    if (oldIndex !== -1) {
+      if (
+        oldData[oldIndex].updateTime !== newDiscussion.updateTime ||
+        oldData[oldIndex].participants !== newDiscussion.participants
+      ) {
+        mergedDiscussions[oldIndex] = newDiscussion;
+      }
+    } else {
+      mergedDiscussions.push(newDiscussion);
+    }
+  });
+
+  return mergedDiscussions;
+}
+
+async function saveDiscussionData(discussions, basePath) {
+  await mkdir(basePath + "/discussions", { recursive: true });
+  if (discussions.length === 0) {
+    return;
+  }
+  const discussionsDir = join(basePath, "discussions");
+  const file = join(discussionsDir, "discussions.json");
+  try {
+    const response = await readFile(file);
+    const oldData = JSON.parse(response.toString());
+    const mergedData = await mergeDiscussions(oldData, discussions);
+    const jsonData = JSON.stringify(mergedData, null, 2);
+    await writeFile(file, jsonData);
+  } catch (err) {
+    const jsonData = JSON.stringify(discussions, null, 2);
+    await writeFile(file, jsonData);
+  }
+}
+
 async function main() {
   const userActivities = await getUserActivities();
 
@@ -228,6 +385,31 @@ async function main() {
       );
     }),
   );
+
+  const startDate = new Date("2021-01-01");
+  const endDate = new Date(Date.now());
+
+  console.log(
+    "Fetching discussions between " +
+      startDate.toLocaleDateString() +
+      " and " +
+      endDate.toLocaleDateString(),
+  );
+
+  try {
+    const allDiscussions = await getAllDiscussions(endDate, startDate);
+    const parsedDiscussions = await parseDiscussionData(
+      allDiscussions,
+      endDate,
+      startDate,
+    );
+    console.log(
+      "Saving discussions to " + basePath + "/discussions/discussions.json",
+    );
+    await saveDiscussionData(parsedDiscussions, basePath);
+  } catch (error) {
+    throw new Error(`Error fetching discussions: ${error.message}`);
+  }
 
   console.log("Completed");
 }


### PR DESCRIPTION
- Fixes #467 

**MOST RECENT DISCUSSION FETCHED**
![image](https://github.com/user-attachments/assets/5709770d-ac2b-4a96-b931-59d9d27ace44)

**OLDEST DISCUSSION FETCHED** (23 April 2021)
![image](https://github.com/user-attachments/assets/8c61b182-689f-4ffe-98ac-ff690dc2ad1f)
